### PR TITLE
clear .once handlers after they've been fired once

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -23,6 +23,9 @@ class EventEmitter {
     event = event.trim()
     this.handle(event, this.#handlers)
     this.handle(event, this.#oncehandlers)
+
+    // Clear the onceHandlers after emitting
+    this.#oncehandlers[event] = [];
   }
 
   handle (event, handlers) {

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -1,4 +1,5 @@
 import test from '../index.js'
+import { ref } from '../lib/runner.js';
 
 test.autostart = false
 test.onEnd(() => check(true, 'test.onEnd ran'))
@@ -85,6 +86,29 @@ test('ok()', t => {
 
   t.end()
 })
+
+test('EventEmitter .once handler should not be fired more than once', function(t){
+  let eventEmitter = ref.get('emitter');
+  let handlerCalled = 0;
+
+  eventEmitter.once('testEmit', () => handlerCalled++);
+
+  eventEmitter.emit('testEmit');
+
+  check(handlerCalled === 1, 'Handler should have been called once');
+
+  eventEmitter.emit('testEmit');
+
+  check(handlerCalled === 1, 'Handler should have been called once (after second emit)');
+
+  eventEmitter.emit('testEmit');
+
+  check(handlerCalled === 1, 'Handler should have been called once (after third emit)');
+
+  queue = [queue[0]]
+
+  t.end();
+});
 
 test.start()
 


### PR DESCRIPTION
- add unit test to basic.js
- fixes #4  